### PR TITLE
chore(deps): Upgrade deps for xmldom security fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,21 +4027,14 @@
       }
     },
     "xml-encryption": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.4.tgz",
-      "integrity": "sha512-+4aSBIv/lwmv5PntfYsZyelOnCcyDmCt/MNxXUukRGlcWW8DObJ26obbVX3iXYRdqkLqbv3AKk8ntNCGKIq/UQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.3.0.tgz",
+      "integrity": "sha512-3P8C4egMMxSR1BmsRM+fG16a3WzOuUEQKS2U4c3AZ5v7OseIfdUeVkD8dwxIhuLryFZSRWUL5OP6oqkgU7hguA==",
       "requires": {
+        "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
         "node-forge": "^0.10.0",
-        "xmldom": "~0.6.0",
         "xpath": "0.0.32"
-      },
-      "dependencies": {
-        "xmldom": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-          "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
-        }
       }
     },
     "xml2json-light": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "base-64": "^1.0.0",
     "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.21",
-    "xml-crypto": "^2.1.2",
-    "xml-encryption": "^1.2.4",
+    "xml-crypto": "^2.1.3",
+    "xml-encryption": "^1.3.0",
     "xml2json-light": "^1.0.6",
     "xpath": "0.0.32"
   },


### PR DESCRIPTION
## Context

package [xml-encryption](https://www.npmjs.com/package/xml-encryption) was still fetching a vulnerable version of xmldom and Snyk reported this as [an issue](https://app.snyk.io/org/formsg/project/7d2653ec-310a-4c60-a94a-eca85308e725#issue-SNYK-JS-XMLDOM-1534562).

## Approach

Explicit upgrade of xml-crypto and xml-encryption to latest tag  to upgrade xmldom internally

cc @LoneRifle 

